### PR TITLE
(Do not merge) REL: old version 0.15.8 for v0.15.x branch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "apischema" %}
-{% set version = "0.17.0" %}
+{% set version = "0.15.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/wyfo/apischema/archive/v{{ version }}.tar.gz
-  sha256: cb29552b91149777e2a970e228114cf817de2347540f3bf1e2b6841747363fb5
+  sha256: f99988c0edb30ab49b24e99cfd41cf68b9b76f54d7df6b33083cfc3c8fa98d7a
 
 build:
   noarch: python


### PR DESCRIPTION
Closes #17 (will make a separate branch; testing the build for now)

Following this to release the old version v0.15.x track: https://conda-forge.org/docs/maintainer/updating_pkgs.html#maintaining-several-versions

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
